### PR TITLE
fix: correct BoneOfFate inventory enumeration

### DIFF
--- a/Content.Goobstation.Server/FateArcade/BoneOfFateSystem.cs
+++ b/Content.Goobstation.Server/FateArcade/BoneOfFateSystem.cs
@@ -67,7 +67,7 @@ public sealed class BoneOfFateSystem : EntitySystem
                 _popup.PopupEntity("Your equipment disintegrates!", uid, user);
                 if (TryComp<InventoryComponent>(user, out var inv))
                 {
-                    var enumerator = new InventorySlotEnumerator(inv);
+                    var enumerator = new InventorySystem.InventorySlotEnumerator(inv);
                     while (enumerator.NextItem(out var item))
                         QueueDel(item);
                 }
@@ -90,7 +90,7 @@ public sealed class BoneOfFateSystem : EntitySystem
                 break;
             case 8:
                 _popup.PopupEntity("You explode!", uid, user);
-                _explosion.QueueExplosion(user, ExplosionSystem.DefaultExplosionPrototypeId, 20, 3, 5, user);
+                _explosion.QueueExplosion(user, ExplosionSystem.DefaultExplosionPrototypeId, 20, 3, 5, user: user);
                 break;
             case 9:
                 _popup.PopupEntity("You catch a cold.", uid, user);


### PR DESCRIPTION
## Summary
- qualify BoneOfFate inventory enumerator to InventorySystem.InventorySlotEnumerator
- name explosion user parameter for clarity

## Testing
- `dotnet build Content.Goobstation.Server/Content.Goobstation.Server.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b52f3f486c8331994c7de022b707bd